### PR TITLE
Allow timeout to complete

### DIFF
--- a/client.go
+++ b/client.go
@@ -335,6 +335,8 @@ func (c *client) query(params *QueryParam) error {
 				inp.sent = true
 				select {
 				case params.Entries <- inp:
+				case <-finish:
+					return nil
 				}
 			} else {
 				// Fire off a node specific query


### PR DESCRIPTION
When the timeout it reached, the query can still fail to complete if the
caller isn't consuming the results from the channel.  This change allows
the query to exit in any case.