### PR TITLE
Fixes new client or server creation failure when one of ipv4 or ipv6 is unavailable

### DIFF
--- a/client.go
+++ b/client.go
@@ -191,6 +191,13 @@ func newClient() (*client, error) {
 		return nil, fmt.Errorf("failed to bind to any unicast udp port")
 	}
 
+	if uconn4 == nil {
+		uconn4 = &net.UDPConn{}
+	}
+	if uconn6 == nil {
+		uconn6 = &net.UDPConn{}
+	}
+
 	mconn4, err := net.ListenUDP("udp4", mdnsWildcardAddrIPv4)
 	if err != nil {
 		log.Printf("[ERR] mdns: Failed to bind to udp4 port: %v", err)
@@ -202,6 +209,13 @@ func newClient() (*client, error) {
 
 	if mconn4 == nil && mconn6 == nil {
 		return nil, fmt.Errorf("failed to bind to any multicast udp port")
+	}
+
+	if mconn4 == nil {
+		mconn4 = &net.UDPConn{}
+	}
+	if mconn6 == nil {
+		mconn6 = &net.UDPConn{}
 	}
 
 	p1 := ipv4.NewPacketConn(mconn4)

--- a/server.go
+++ b/server.go
@@ -73,6 +73,13 @@ func NewServer(config *Config) (*Server, error) {
 		return nil, fmt.Errorf("[ERR] mdns: Failed to bind to any udp port!")
 	}
 
+	if ipv4List == nil {
+		ipv4List = &net.UDPConn{}
+	}
+	if ipv6List == nil {
+		ipv6List = &net.UDPConn{}
+	}
+
 	// Join multicast groups to receive announcements
 	p1 := ipv4.NewPacketConn(ipv4List)
 	p2 := ipv6.NewPacketConn(ipv6List)
@@ -112,13 +119,8 @@ func NewServer(config *Config) (*Server, error) {
 		shutdownCh: make(chan struct{}),
 	}
 
-	if ipv4List != nil {
-		go s.recv(s.ipv4List)
-	}
-
-	if ipv6List != nil {
-		go s.recv(s.ipv6List)
-	}
+	go s.recv(s.ipv4List)
+	go s.recv(s.ipv6List)
 
 	s.wg.Add(1)
 	go s.probe()


### PR DESCRIPTION
On my Linux machine it was failing to create a new server or client because I have ipv6 disabled.
Specifically, it was failing in this call `ipv6.NewPacketConn(ipv6List)` with `ipv6List = nil`.
I tried to fix the issue by applying the minimum changes.
This means that if any of  `*UDPConn` is nil, an empty assignment is taking place.
If you are ok with fixing the issue but have efficiency concerns due to the "meaningless" calls
with the empty placeholders, I can try change those parts with nil checks.